### PR TITLE
Add h namespace

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -2,7 +2,7 @@
     "Stencil Component": {
         "prefix": "st-component",
         "body": [
-            "import { Component } from '@stencil/core';",
+            "import { Component, h } from '@stencil/core';",
             "",
             "",
             "@Component({",


### PR DESCRIPTION
The "h" namespace is used to import JSX types for elements and attributes